### PR TITLE
Vectorize algorithms, remove log_sum_exp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ Homepage = "https://github.com/atuanpham/python-markov"
 packages = ["src/markov"]
 
 [tool.black]
-line-length = 88
+line-length = 100
 target-version = ['py39']
 include = '\.pyi?$'
 extend-exclude = '''
@@ -72,7 +72,7 @@ extend-exclude = '''
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-line_length = 88
+line_length = 100
 known_first_party = ["markov"]
 
 [tool.mypy]

--- a/src/markov/core/algorithms.py
+++ b/src/markov/core/algorithms.py
@@ -6,15 +6,9 @@ from typing import List, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.special import logsumexp
 
-from ..utils.math_utils import (
-    EPSILON,
-    LOG_ZERO,
-    log_sum_exp,
-    normalize_log_probs_axis,
-    safe_exp,
-    safe_log,
-)
+from ..utils.math_utils import EPSILON, LOG_ZERO, normalize_log_probs_axis, safe_exp, safe_log
 
 
 def forward_algorithm(
@@ -41,17 +35,12 @@ def forward_algorithm(
     # Initial step: π_i * b_i(o_1)
     log_forward[0] = log_start_probs + log_emission_probs[0]
 
-    # Forward recursion
     for t in range(1, T):
-        for j in range(n_states):
-            # Sum over all previous states
-            log_forward[t, j] = (
-                log_sum_exp(log_forward[t - 1] + log_transition_probs[:, j])
-                + log_emission_probs[t, j]
-            )
+        transition_scores = log_forward[t - 1][:, np.newaxis] + log_transition_probs
+        log_forward[t] = logsumexp(transition_scores, axis=0) + log_emission_probs[t]
 
     # Compute log-likelihood
-    log_likelihood = log_sum_exp(log_forward[T - 1])
+    log_likelihood = logsumexp(log_forward[T - 1])
 
     return log_forward, log_likelihood
 
@@ -79,13 +68,8 @@ def backward_algorithm(
 
     # Backward recursion
     for t in range(T - 2, -1, -1):
-        for i in range(n_states):
-            # Sum over all next states
-            log_backward[t, i] = log_sum_exp(
-                log_transition_probs[i]
-                + log_emission_probs[t + 1]
-                + log_backward[t + 1]
-            )
+        next_scores = log_transition_probs + log_emission_probs[t + 1] + log_backward[t + 1]
+        log_backward[t] = logsumexp(next_scores, axis=1)
 
     return log_backward
 
@@ -117,15 +101,10 @@ def viterbi_algorithm(
 
     # Forward pass
     for t in range(1, T):
-        for j in range(n_states):
-            # Find most likely previous state
-            transition_scores = log_viterbi[t - 1] + log_transition_probs[:, j]
-            best_prev_state = np.argmax(transition_scores)
+        transition_scores = log_viterbi[t - 1][:, np.newaxis] + log_transition_probs
 
-            log_viterbi[t, j] = (
-                transition_scores[best_prev_state] + log_emission_probs[t, j]
-            )
-            path[t, j] = best_prev_state
+        path[t] = np.argmax(transition_scores, axis=0)
+        log_viterbi[t] = np.max(transition_scores, axis=0) + log_emission_probs[t]
 
     # Find best final state
     best_final_state = np.argmax(log_viterbi[T - 1])
@@ -172,16 +151,13 @@ def forward_backward_algorithm(
     # Compute xi (posterior transition probabilities)
     log_xi = np.full((T - 1, n_states, n_states), LOG_ZERO, dtype=np.float64)
 
-    for t in range(T - 1):
-        for i in range(n_states):
-            for j in range(n_states):
-                log_xi[t, i, j] = (
-                    log_forward[t, i]
-                    + log_transition_probs[i, j]
-                    + log_emission_probs[t + 1, j]
-                    + log_backward[t + 1, j]
-                    - log_likelihood
-                )
+    log_xi = (
+        log_forward[:-1, :, np.newaxis]
+        + log_transition_probs[np.newaxis, :, :]
+        + log_emission_probs[1:, np.newaxis, :]
+        + log_backward[1:, np.newaxis, :]
+        - log_likelihood
+    )
 
     return safe_exp(log_gamma), safe_exp(log_xi), log_likelihood
 

--- a/src/markov/core/discrete.py
+++ b/src/markov/core/discrete.py
@@ -8,12 +8,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ..exceptions import ModelNotFittedError
-from ..utils.math_utils import (
-    EPSILON,
-    make_stochastic,
-    random_stochastic_matrix,
-    safe_log,
-)
+from ..utils.math_utils import EPSILON, make_stochastic, random_stochastic_matrix, safe_log
 from ..utils.validation import (
     validate_n_observations,
     validate_n_states,
@@ -91,9 +86,7 @@ class DiscreteEmissionModel(EmissionModel):
 
         for t in range(T):
             for state in range(self.n_states):
-                log_emission_probs[t, state] = safe_log(
-                    self.emission_probs[state, sequence[t]]
-                )
+                log_emission_probs[t, state] = safe_log(self.emission_probs[state, sequence[t]])
 
         return log_emission_probs
 
@@ -188,9 +181,7 @@ class DiscreteHMM(BaseHMM):
         >>> log_prob = hmm.score(test_seq)
     """
 
-    def __init__(
-        self, n_states: int, n_observations: int, random_state: Optional[int] = None
-    ):
+    def __init__(self, n_states: int, n_observations: int, random_state: Optional[int] = None):
         """
         Initialize discrete HMM.
 

--- a/src/markov/utils/math_utils.py
+++ b/src/markov/utils/math_utils.py
@@ -2,70 +2,16 @@
 Mathematical utilities for numerical stability in HMM computations.
 """
 
-import warnings
 from typing import Union
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.special import logsumexp
 
 # Constants for numerical stability
 LOG_ZERO = -np.inf
 EPSILON = 1e-12
 MAX_LOG_EXP = 700.0  # Prevents overflow in exp()
-
-
-def log_sum_exp(log_probs: NDArray[np.float64]) -> float:
-    """
-    Compute log(sum(exp(x))) in a numerically stable way.
-
-    Args:
-        log_probs: Array of log probabilities
-
-    Returns:
-        Log of sum of exponentials
-    """
-    if len(log_probs) == 0:
-        return LOG_ZERO
-
-    max_log = np.max(log_probs)
-
-    # Handle case where all probabilities are zero
-    if max_log == LOG_ZERO:
-        return LOG_ZERO
-
-    # Prevent overflow by subtracting max
-    if max_log > MAX_LOG_EXP:
-        warnings.warn("Large log probabilities detected, potential numerical issues")
-
-    return max_log + np.log(np.sum(np.exp(log_probs - max_log)))
-
-
-def log_sum_exp_axis(log_probs: NDArray[np.float64], axis: int) -> NDArray[np.float64]:
-    """
-    Compute log(sum(exp(x))) along specified axis in numerically stable way.
-
-    Args:
-        log_probs: Array of log probabilities
-        axis: Axis along which to compute
-
-    Returns:
-        Log of sum of exponentials along axis
-    """
-    max_log = np.max(log_probs, axis=axis, keepdims=True)
-
-    # Handle -inf values
-    inf_mask = np.isinf(max_log)
-    max_log = np.where(inf_mask, 0, max_log)
-
-    result = max_log.squeeze(axis) + np.log(
-        np.sum(np.exp(log_probs - max_log), axis=axis)
-    )
-
-    # Set -inf where all inputs were -inf
-    if np.any(inf_mask):
-        result = np.where(inf_mask.squeeze(axis), LOG_ZERO, result)
-
-    return result
 
 
 def normalize_log_probs(log_probs: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -78,7 +24,7 @@ def normalize_log_probs(log_probs: NDArray[np.float64]) -> NDArray[np.float64]:
     Returns:
         Normalized log probabilities
     """
-    log_sum = log_sum_exp(log_probs)
+    log_sum = logsumexp(log_probs)
     if log_sum == LOG_ZERO:
         # If all probabilities are zero, return uniform
         return np.full_like(log_probs, -np.log(len(log_probs)))
@@ -86,9 +32,7 @@ def normalize_log_probs(log_probs: NDArray[np.float64]) -> NDArray[np.float64]:
     return log_probs - log_sum
 
 
-def normalize_log_probs_axis(
-    log_probs: NDArray[np.float64], axis: int
-) -> NDArray[np.float64]:
+def normalize_log_probs_axis(log_probs: NDArray[np.float64], axis: int) -> NDArray[np.float64]:
     """
     Normalize log probabilities along specified axis.
 
@@ -99,7 +43,7 @@ def normalize_log_probs_axis(
     Returns:
         Normalized log probabilities
     """
-    log_sum = log_sum_exp_axis(log_probs, axis)
+    log_sum = logsumexp(log_probs, axis=axis)
     return log_probs - np.expand_dims(log_sum, axis)
 
 
@@ -133,9 +77,7 @@ def safe_exp(
     return np.exp(np.clip(log_x, -MAX_LOG_EXP, MAX_LOG_EXP))
 
 
-def log_dot_product(
-    log_A: NDArray[np.float64], log_B: NDArray[np.float64]
-) -> NDArray[np.float64]:
+def log_dot_product(log_A: NDArray[np.float64], log_B: NDArray[np.float64]) -> NDArray[np.float64]:
     """
     Compute log(A @ exp(B)) in numerically stable way.
 
@@ -156,7 +98,7 @@ def log_dot_product(
     log_products = log_A_expanded + log_B_expanded
 
     # Sum along middle dimension in log space
-    return log_sum_exp_axis(log_products, axis=1).squeeze()
+    return logsumexp(log_products, axis=1).squeeze()
 
 
 def check_probability_matrix(
@@ -238,9 +180,7 @@ def random_stochastic_matrix(
     return make_stochastic(matrix, axis=1)
 
 
-def weighted_average(
-    values: NDArray[np.float64], weights: NDArray[np.float64]
-) -> float:
+def weighted_average(values: NDArray[np.float64], weights: NDArray[np.float64]) -> float:
     """
     Compute weighted average with numerical stability.
 

--- a/src/markov/utils/validation.py
+++ b/src/markov/utils/validation.py
@@ -43,9 +43,7 @@ def validate_sequence(sequence: NDArray, n_observations: Optional[int] = None) -
             raise ValidationError("Discrete sequences must contain integers")
 
         if np.any((sequence < 0) | (sequence >= n_observations)):
-            raise ValidationError(
-                f"Observations must be in range [0, {n_observations-1}]"
-            )
+            raise ValidationError(f"Observations must be in range [0, {n_observations-1}]")
 
 
 def validate_sequences(
@@ -78,9 +76,7 @@ def validate_sequences(
     return validated
 
 
-def validate_probability_vector(
-    probs: NDArray[np.float64], name: str = "probabilities"
-) -> None:
+def validate_probability_vector(probs: NDArray[np.float64], name: str = "probabilities") -> None:
     """Validate probability vector sums to 1 and is non-negative."""
     if not isinstance(probs, np.ndarray):
         raise ValidationError(f"{name} must be numpy array")
@@ -134,8 +130,7 @@ def validate_hmm_parameters(
         validate_probability_matrix(emission_probs, axis=1, name="emission_probs")
         if emission_probs.shape[0] != n_states:
             raise IncompatibleShapeError(
-                f"emission_probs has {emission_probs.shape[0]} states, "
-                f"expected {n_states}"
+                f"emission_probs has {emission_probs.shape[0]} states, " f"expected {n_states}"
             )
 
 

--- a/tests/test_discrete_hmm.py
+++ b/tests/test_discrete_hmm.py
@@ -563,10 +563,8 @@ class TestDiscreteHMMIntegration:
         # Check that training improved likelihood
         assert len(test_hmm.log_likelihood_history_) > 0
         if len(test_hmm.log_likelihood_history_) > 1:
-            assert (
-                test_hmm.log_likelihood_history_[-1]
-                >= test_hmm.log_likelihood_history_[0] - 1e-6
-            )
+            log_likelyhood_0 = test_hmm.log_likelihood_history_[0] - 1e-6
+            assert test_hmm.log_likelihood_history_[-1] >= log_likelyhood_0
 
         # Test model works on test data
         test_seq = sequences[0][:5]  # First 5 observations

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -2,10 +2,9 @@
 Tests for mathematical utilities module.
 """
 
-import warnings
-
 import numpy as np
 import pytest
+from scipy.special import logsumexp
 
 from markov.utils.math_utils import (
     EPSILON,
@@ -14,8 +13,6 @@ from markov.utils.math_utils import (
     check_probability_matrix,
     log_dot_product,
     log_likelihood_change,
-    log_sum_exp,
-    log_sum_exp_axis,
     make_stochastic,
     normalize_log_probs,
     normalize_log_probs_axis,
@@ -24,105 +21,6 @@ from markov.utils.math_utils import (
     safe_log,
     weighted_average,
 )
-
-
-class TestLogSumExp:
-    """Tests for log_sum_exp function."""
-
-    def test_empty_array(self):
-        """Test log_sum_exp with empty array."""
-        result = log_sum_exp(np.array([]))
-        assert result == LOG_ZERO
-
-    def test_single_value(self):
-        """Test log_sum_exp with single value."""
-        x = 2.5
-        result = log_sum_exp(np.array([x]))
-        assert np.isclose(result, x)
-
-    def test_two_values(self):
-        """Test log_sum_exp with two values."""
-        x1, x2 = 1.0, 2.0
-        expected = np.log(np.exp(x1) + np.exp(x2))
-        result = log_sum_exp(np.array([x1, x2]))
-        assert np.isclose(result, expected)
-
-    def test_all_zero_log_probs(self):
-        """Test with all -inf (zero probabilities)."""
-        log_probs = np.array([LOG_ZERO, LOG_ZERO, LOG_ZERO])
-        result = log_sum_exp(log_probs)
-        assert result == LOG_ZERO
-
-    def test_numerical_stability(self):
-        """Test numerically challenging case."""
-        # Large values that would overflow without stability measures
-        log_probs = np.array([1000.0, 1001.0, 999.0])
-        result = log_sum_exp(log_probs)
-
-        # Should not be inf or nan
-        assert np.isfinite(result)
-
-        # Should be dominated by largest value
-        assert result > 1001.0
-
-    def test_mixed_finite_infinite(self):
-        """Test mix of finite and -inf values."""
-        log_probs = np.array([1.0, LOG_ZERO, 2.0, LOG_ZERO])
-        expected = np.log(np.exp(1.0) + np.exp(2.0))
-        result = log_sum_exp(log_probs)
-        assert np.isclose(result, expected)
-
-    def test_warning_on_large_values(self):
-        """Test warning is issued for very large values."""
-        log_probs = np.array([800.0, 801.0])
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            log_sum_exp(log_probs)
-            assert len(w) == 1
-            assert "Large log probabilities" in str(w[0].message)
-
-
-class TestLogSumExpAxis:
-    """Tests for log_sum_exp_axis function."""
-
-    def test_2d_array_axis_0(self):
-        """Test log_sum_exp along axis 0."""
-        log_probs = np.array([[1.0, 2.0], [3.0, 4.0]])
-        result = log_sum_exp_axis(log_probs, axis=0)
-
-        expected = np.array(
-            [log_sum_exp(np.array([1.0, 3.0])), log_sum_exp(np.array([2.0, 4.0]))]
-        )
-
-        assert np.allclose(result, expected)
-
-    def test_2d_array_axis_1(self):
-        """Test log_sum_exp along axis 1."""
-        log_probs = np.array([[1.0, 2.0], [3.0, 4.0]])
-        result = log_sum_exp_axis(log_probs, axis=1)
-
-        expected = np.array(
-            [log_sum_exp(np.array([1.0, 2.0])), log_sum_exp(np.array([3.0, 4.0]))]
-        )
-
-        assert np.allclose(result, expected)
-
-    def test_with_infinite_values(self):
-        """Test handling of -inf values."""
-        log_probs = np.array([[LOG_ZERO, 1.0], [2.0, LOG_ZERO]])
-        result = log_sum_exp_axis(log_probs, axis=1)
-
-        expected = np.array([1.0, 2.0])
-        assert np.allclose(result, expected)
-
-    def test_all_infinite_row(self):
-        """Test row with all -inf values."""
-        log_probs = np.array([[LOG_ZERO, LOG_ZERO], [1.0, 2.0]])
-        result = log_sum_exp_axis(log_probs, axis=1)
-
-        assert result[0] == LOG_ZERO
-        assert np.isfinite(result[1])
 
 
 class TestNormalizeLogProbs:
@@ -416,7 +314,7 @@ class TestEdgeCases:
         """Test functions with empty arrays where applicable."""
         empty = np.array([])
 
-        assert log_sum_exp(empty) == LOG_ZERO
+        assert logsumexp(empty) == LOG_ZERO
 
         # Other functions should handle empty arrays gracefully
         result = safe_log(empty)
@@ -429,7 +327,7 @@ class TestEdgeCases:
         """Test functions with single-element arrays."""
         single = np.array([2.5])
 
-        assert np.isclose(log_sum_exp(single), 2.5)
+        assert np.isclose(logsumexp(single), 2.5)
         assert np.isclose(safe_log(np.exp(single[0])), single[0])
         assert np.isclose(safe_exp(single[0]), np.exp(single[0]))
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -295,10 +295,7 @@ class TestModelEvaluation:
 
         # Check test metrics
         test_metrics = result["test"]
-        assert all(
-            key in test_metrics
-            for key in ["log_likelihood", "aic", "bic", "perplexity"]
-        )
+        assert all(key in test_metrics for key in ["log_likelihood", "aic", "bic", "perplexity"])
 
         # Check model info
         model_info = result["model"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -113,9 +113,7 @@ class TestValidateSequence:
         """Test discrete sequence specific validation."""
         # Non-integer values
         seq = np.array([0.5, 1.2, 2.8])
-        with pytest.raises(
-            ValidationError, match="Discrete sequences must contain integers"
-        ):
+        with pytest.raises(ValidationError, match="Discrete sequences must contain integers"):
             validate_sequence(seq, n_observations=3)
 
         # Out of range values
@@ -155,14 +153,10 @@ class TestValidateSequences:
 
     def test_invalid_type(self):
         """Test invalid sequence types."""
-        with pytest.raises(
-            ValidationError, match="Sequences must be list or numpy array"
-        ):
+        with pytest.raises(ValidationError, match="Sequences must be list or numpy array"):
             validate_sequences("invalid")
 
-        with pytest.raises(
-            ValidationError, match="Sequences must be list or numpy array"
-        ):
+        with pytest.raises(ValidationError, match="Sequences must be list or numpy array"):
             validate_sequences(123)
 
     def test_invalid_dimensions(self):
@@ -203,9 +197,7 @@ class TestValidateProbabilityVector:
     def test_invalid_dimensions(self):
         """Test invalid dimensions."""
         probs = np.array([[0.3, 0.7], [0.4, 0.6]])
-        with pytest.raises(
-            ValidationError, match="probabilities must be 1-dimensional"
-        ):
+        with pytest.raises(ValidationError, match="probabilities must be 1-dimensional"):
             validate_probability_vector(probs)
 
     def test_negative_values(self):
@@ -246,41 +238,31 @@ class TestValidateProbabilityMatrix:
 
     def test_invalid_type(self):
         """Test invalid types."""
-        with pytest.raises(
-            ValidationError, match="probability matrix must be numpy array"
-        ):
+        with pytest.raises(ValidationError, match="probability matrix must be numpy array"):
             validate_probability_matrix([[0.3, 0.7], [0.6, 0.4]])
 
     def test_invalid_dimensions(self):
         """Test invalid dimensions."""
         matrix = np.array([0.3, 0.7])  # 1D
-        with pytest.raises(
-            ValidationError, match="probability matrix must be 2-dimensional"
-        ):
+        with pytest.raises(ValidationError, match="probability matrix must be 2-dimensional"):
             validate_probability_matrix(matrix)
 
     def test_negative_values(self):
         """Test negative values."""
         matrix = np.array([[0.3, 0.7], [-0.1, 1.1]])
-        with pytest.raises(
-            ValidationError, match="probability matrix must be non-negative"
-        ):
+        with pytest.raises(ValidationError, match="probability matrix must be non-negative"):
             validate_probability_matrix(matrix)
 
     def test_not_sum_to_one(self):
         """Test rows/columns that don't sum to 1."""
         matrix = np.array([[0.3, 0.5], [0.6, 0.4]])  # first row sums to 0.8
-        with pytest.raises(
-            ValidationError, match="probability matrix rows/columns must sum to 1"
-        ):
+        with pytest.raises(ValidationError, match="probability matrix rows/columns must sum to 1"):
             validate_probability_matrix(matrix, axis=1)
 
     def test_custom_name(self):
         """Test custom parameter name in error messages."""
         matrix = np.array([[0.3, 0.5], [0.6, 0.4]])
-        with pytest.raises(
-            ValidationError, match="transition_matrix rows/columns must sum to 1"
-        ):
+        with pytest.raises(ValidationError, match="transition_matrix rows/columns must sum to 1"):
             validate_probability_matrix(matrix, axis=1, name="transition_matrix")
 
 
@@ -305,13 +287,9 @@ class TestValidateHMMParameters:
     def test_incompatible_transition_shape(self):
         """Test incompatible transition matrix shape."""
         start_probs = np.array([0.3, 0.7])  # 2 states
-        transition_probs = np.array(
-            [[0.5, 0.3, 0.2], [0.4, 0.3, 0.3], [0.2, 0.3, 0.5]]
-        )  # 3x3
+        transition_probs = np.array([[0.5, 0.3, 0.2], [0.4, 0.3, 0.3], [0.2, 0.3, 0.5]])  # 3x3
 
-        with pytest.raises(
-            IncompatibleShapeError, match="transition_probs shape.*incompatible"
-        ):
+        with pytest.raises(IncompatibleShapeError, match="transition_probs shape.*incompatible"):
             validate_hmm_parameters(start_probs, transition_probs)
 
     def test_incompatible_emission_shape(self):
@@ -320,9 +298,7 @@ class TestValidateHMMParameters:
         transition_probs = np.array([[0.8, 0.2], [0.4, 0.6]])
         emission_probs = np.array([[0.5, 0.5], [0.3, 0.7], [0.4, 0.6]])  # 3 states
 
-        with pytest.raises(
-            IncompatibleShapeError, match="emission_probs has 3 states, expected 2"
-        ):
+        with pytest.raises(IncompatibleShapeError, match="emission_probs has 3 states, expected 2"):
             validate_hmm_parameters(start_probs, transition_probs, emission_probs)
 
 
@@ -396,9 +372,7 @@ class TestCheckArrayFinite:
     def test_custom_name(self):
         """Test custom array name in error messages."""
         arr = np.array([1.0, np.inf, 3.0])
-        with pytest.raises(
-            ValidationError, match="probabilities contains non-finite values"
-        ):
+        with pytest.raises(ValidationError, match="probabilities contains non-finite values"):
             check_array_finite(arr, name="probabilities")
 
 


### PR DESCRIPTION
- Vectorization: Remove nested loop in forward, backward, forward-backward, Viterbi algorithm
- Use logsumexp from scipy: Remove methods log_sum_exp_*
- Update line length to 100, instead of 88